### PR TITLE
Update node assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,16 @@ module.exports = {
   options: {
     nodeAssets: {
       'redux-actions': {
-        import: [{
-          path: 'dist/redux-actions.js',
-          using: [{ transformation: 'amd', as: 'redux-actions' }]
-        }]
+        vendor: ['dist/redux-actions.js']
       }
     }
+  },
+
+  included() {
+    this._super.included.apply(this, arguments);
+
+    this.import('vendor/redux-actions/dist/redux-actions.js', {
+      using: [{ transformation: 'amd', as: 'redux-actions' }]
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-node-assets": "0.1.6",
+    "ember-cli-node-assets": "0.2.0",
     "redux-actions": "^1.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,10 +767,6 @@ broccoli-uglify-sourcemap@^1.0.0:
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
 
-broccoli-unwatched-tree@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz#4312fde04bdafe67a05a967d72cc50b184a9f514"
-
 broccoli-writer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
@@ -1453,13 +1449,13 @@ ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
 
-ember-cli-node-assets@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz#6488a2949048c801ad6d9e33753c7bce32fc1146"
+ember-cli-node-assets@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.0.tgz#5ac52af972f3140adc7f25374d14a067a88937cf"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
-    broccoli-unwatched-tree "^0.1.1"
+    broccoli-source "^1.1.0"
     debug "^2.2.0"
     lodash "^4.5.1"
     resolve "^1.1.7"


### PR DESCRIPTION
Updated ember-cli-node-assets and changed the format of the imports. I think this should ensure that things are always imported, no matter how nested your addons are.